### PR TITLE
Fix #19: If an error throws during an action, `this.currentDispatch` is never cleared and no more actions can process.

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -30,11 +30,16 @@ Dispatcher.prototype.dispatch = function(action) {
     return { resolved: false, waitingOn: [], waitCallback: null };
   });
 
-  this.doDispatchLoop(action);
-
-  setTimeout(function() {
+  // After the current dispatch finishes, its handle must be cleaned up, 
+  // even if an error occurs; otherwise, no actions will be able to execute
+  // again for the lifetime of the application.
+  try {
+    this.doDispatchLoop(action);
+  } catch(e) {
+    throw e;
+  } finally {
     this.currentDispatch = null;
-  }.bind(this));
+  }
 };
 
 Dispatcher.prototype.doDispatchLoop = function(action) {

--- a/test/unit/test_dispatcher.js
+++ b/test/unit/test_dispatcher.js
@@ -23,12 +23,15 @@ describe("Dispatcher", function() {
   });
 
   it("does not allow dispatching while another action is dispatching", function(done) {
-    dispatcher.dispatch();
+    store1.__handleAction__ = function() {
+      dispatcher.dispatch();
+    };
     expect(function() {
       dispatcher.dispatch();
     }).to.throw(/another action/);
 
     setTimeout(function() {
+      store1.__handleAction__ = sinon.spy();
       expect(function() {
         dispatcher.dispatch();
       }).not.to.throw();


### PR DESCRIPTION
Previously, if an error occurred inside an action, the `currentAction` state was never
removed and it would always look as though an action was dispatching, which intentionally
breaks since actions should not cascade.

This commit also subtly changes the protection mechanism that prevents cascading actions.
Previously, two synchronous dispatches would throw an error if they were executed
one after the other. I believe this was incorrect; the spec specifies that dispatches
should not cascade, i.e. an action handler should not trigger another action, but not
that multiple dispatches cannot occur synchronously.

I previously opened an ticket about this issue at #19.
