### PR TITLE
merge getDefaultState to the State

### DIFF
--- a/lib/store_watch_mixin.js
+++ b/lib/store_watch_mixin.js
@@ -22,7 +22,7 @@ var StoreWatchMixin = function() {
     },
 
     getInitialState: function() {
-      if (typeof this.getDefaultState == 'function') {
+      if (typeof this.getDefaultState === 'function') {
         return _assign(this.getDefaultState(), this.getStateFromFlux());
       }
       return this.getStateFromFlux();


### PR DESCRIPTION
According to the doc: https://github.com/BinaryMuse/fluxxor/blob/master/site/contents/documentation/store-watch-mixin.md

this.state is merged with any other getDefaultState functions defined on the component or other mixins

Update the code to comply with the doc. So it can set the initial state
