### PR TITLE
Update version number in bower.json to 1.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "fluxxor",
-  "version": "1.1.3",
+  "version": "1.3.0",
   "main": "build/fluxxor.min.js",
   "description": "Flux architecture tools for React",
   "homepage": "",


### PR DESCRIPTION
Bower complains about non-matching version numbers.
