### PR TITLE
inherits method as a dependency

### DIFF
--- a/lib/create_store.js
+++ b/lib/create_store.js
@@ -1,6 +1,6 @@
 var _each = require("lodash-node/modern/collections/forEach"),
     Store = require("./store"),
-    util = require("util");
+    inherits = require("inherits");
 
 var RESERVED_KEYS = ["flux", "waitFor"];
 
@@ -32,7 +32,7 @@ var createStore = function(spec) {
     }
   };
 
-  util.inherits(constructor, Store);
+  inherits(constructor, Store);
   return constructor;
 };
 

--- a/lib/store.js
+++ b/lib/store.js
@@ -1,5 +1,5 @@
 var EventEmitter = require("events").EventEmitter,
-    util = require("util");
+    inherits = require("inherits");
 
 function Store(dispatcher) {
   this.dispatcher = dispatcher;
@@ -7,7 +7,7 @@ function Store(dispatcher) {
   EventEmitter.call(this);
 }
 
-util.inherits(Store, EventEmitter);
+inherits(Store, EventEmitter);
 
 Store.prototype.__handleAction__ = function(action) {
   var handler;

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "chai": "^1.9.1",
     "css-loader": "^0.6.12",
     "envify": "^1.2.1",
+    "inherits": "^2.0.1",
     "jsdom": "^0.10.5",
     "json-loader": "^0.5.0",
     "jsx-loader": "^0.10.2",
@@ -56,6 +57,11 @@
     "trailing": true,
     "node": true,
     "browser": true,
-    "predef": ["it", "describe", "beforeEach", "afterEach"]
+    "predef": [
+      "it",
+      "describe",
+      "beforeEach",
+      "afterEach"
+    ]
   }
 }


### PR DESCRIPTION
When using the util library, a lot of extra unneeded code is added to the build. By only requiring the inherits package saves about 7kb in filesize (when minified!)
