### PR TITLE
Add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,6 @@
+build/
+examples/
+test/
+site/
+script/
+fluxxor.svg


### PR DESCRIPTION
This package is much larger than it needs to be on npm.

Original:

```
~/g/f/fluxxor ((1.4.1)|…) $ npm pack
fluxxor-1.4.1.tgz
~/g/f/fluxxor ((1.4.1)|…) $ wc -c fluxxor-1.4.1.tgz
 3477805 fluxxor-1.4.1.tgz
```

With the `.npmignore` from this patch:

```
~/g/f/fluxxor (npmignore|…) $ wc -c fluxxor-1.4.1.tgz
   12854 fluxxor-1.4.1.tgz
```
