### PR TITLE
Modular api to satisfy #68

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -10,15 +10,20 @@ var _clone = require("lodash-node/modern/objects/clone"),
     _uniq = require("lodash-node/modern/arrays/uniq");
 
 var Dispatcher = function(stores) {
-  this.stores = stores;
+  this.stores = {};
   this.currentDispatch = null;
   this.waitingToDispatch = [];
 
   for (var key in stores) {
     if (stores.hasOwnProperty(key)) {
-      stores[key].dispatcher = this;
+      this.addStore(key, stores[key]);
     }
   }
+};
+
+Dispatcher.prototype.addStore = function(name, store) {
+  store.dispatcher = this;
+  this.stores[name] = store;
 };
 
 Dispatcher.prototype.dispatch = function(action) {

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -4,39 +4,100 @@ function bindActions(target, actions, dispatchBinder) {
   for (var key in actions) {
     if (actions.hasOwnProperty(key)) {
       if (typeof actions[key] === "function") {
-        target[key] = actions[key].bind(dispatchBinder);
+        if (target[key] === undefined) {
+          target[key] = actions[key].bind(dispatchBinder);
+        } else {
+          // TODO: pass in the sequence of keys by which we arrived here to provide in the error
+          throw new Error("An action by the name of '" + key + "' already exists here");
+        }
       } else if (typeof actions[key] === "object") {
-        target[key] = {};
+        if (typeof target[key] === "function") {
+          throw new Error("An action by the name of '" + key + "' already exists where namespace was expected");
+        } else if (target[key] === undefined) {
+          target[key] = {}; 
+        }
         bindActions(target[key], actions[key], dispatchBinder);
-      }
-    }
+      }   
+    }   
   }
 }
 
 var Flux = function(stores, actions) {
-  var dispatcher = new Dispatcher(stores),
-      dispatchBinder = {
+  this.dispatcher = new Dispatcher(stores);
+  this.actions = {};
+  this.stores = {};
+
+  this.addActions(actions);
+  this.addStores(stores);
+
+};
+
+Flux.prototype.addActions = function(actions) {
+  var dispatcher = this.dispatcher,
+      dispatchBinder = { 
         flux: this,
         dispatch: function(type, payload) {
           dispatcher.dispatch({type: type, payload: payload});
         }
-      };
-
-  this.dispatcher = dispatcher;
-  this.actions = {};
-  this.stores = stores;
-
+      };  
+  
   bindActions(this.actions, actions, dispatchBinder);
+};
 
-  for (var key in stores) {
-    if (stores.hasOwnProperty(key)) {
-      stores[key].flux = this;
+// addAction has two signatures:
+// 1: string[, string, string, string...], actionFunction
+// 2: arrayOfStrings, actionFunction
+Flux.prototype.addAction = function() {
+  if (arguments.length < 2) {
+    throw new Error("addAction requires at least two arguments, a string (or array of strings), and a function");
+  }
+  var hasSignature1 = typeof arguments[0] === "string";
+  if (hasSignature1) {
+    var args = []; 
+    for (var i = 0; i<arguments.length; i++) {
+      if (typeof arguments[i] === "string") {
+        args.push(arguments[i]);
+      } else if (typeof arguments[i] === "function" && i===arguments.length-1) {
+        return this.addAction(args, arguments[i]);
+      } else {
+        throw new Error("didn't understand argument " + (i+1) + " to addAction");
+      }   
+    }   
+    throw new Error("didn't find action function in " + arguments.length + " arguments to addAction");
+  } else {
+    var keys = arguments[0];
+    var actionFunc = arguments[1];
+    var actions = {}; 
+    actions[keys.pop()] = actionFunc;
+    while (keys.length) {
+      var key = keys.pop();
+      var outer = {}; 
+      outer[key] = actions;
+      actions = outer;
     }
+    this.addActions(actions);
   }
 };
 
 Flux.prototype.store = function(name) {
   return this.stores[name];
+};
+
+Flux.prototype.addStore = function(name, store) {
+  if (name in this.stores) {
+    throw new Error("A store keyed by '" + name + "' already exists");
+  }
+  store.flux = this;
+  this.stores[name] = store;
+  this.dispatcher.addStore(name, store);
+};
+
+Flux.prototype.addStores = function(stores) {
+  for (var key in stores) {
+    if (stores.hasOwnProperty(key)) {
+      this.addStore(key, stores[key]);
+    }
+  }
 };
 
 module.exports = Flux;


### PR DESCRIPTION
This implements a superset of the API mentioned in #68 with addActions/addStores supporting the current object format (and used by the Flux constructor), and addAction/addStore supporting the one-at-a-time notion.  

Flux#addStore takes a name and a store, and adds the store to Flux.

Flux#addAction takes either an array of namespaces and an action function, or any number of namespaces as strings, and then an action function.   

bindActions was changed to throw when encountering a collision.

I didn't check in any documentation, but I can do so if you'd prefer that to writing it yourself.
