### PR TITLE
more information in dispatch-within-dispatch error

### DIFF
--- a/lib/dispatcher.js
+++ b/lib/dispatcher.js
@@ -12,6 +12,7 @@ var _clone = require("lodash-node/modern/objects/clone"),
 var Dispatcher = function(stores) {
   this.stores = stores;
   this.currentDispatch = null;
+  this.currentActionType = null;
   this.waitingToDispatch = [];
 
   for (var key in stores) {
@@ -22,16 +23,19 @@ var Dispatcher = function(stores) {
 };
 
 Dispatcher.prototype.dispatch = function(action) {
-  if (this.currentDispatch) {
-    throw new Error("Cannot dispatch an action while another action is being dispatched");
-  }
-
   if (!action || !action.type) {
     throw new Error("Can only dispatch actions with a 'type' property");
   }
 
+  if (this.currentDispatch) {
+    var complaint = "Cannot dispatch an action ('" + action.type + "') while another action ('" +
+                    this.currentActionType + "') is being dispatched";
+    throw new Error(complaint);
+  }
+
   this.waitingToDispatch = _clone(this.stores);
 
+  this.currentActionType = action.type;
   this.currentDispatch = _mapValues(this.stores, function() {
     return { resolved: false, waitingOn: [], waitCallback: null };
   });
@@ -39,6 +43,7 @@ Dispatcher.prototype.dispatch = function(action) {
   try {
     this.doDispatchLoop(action);
   } finally {
+    this.currentActionType = null;
     this.currentDispatch = null;
   }
 };

--- a/test/unit/test_dispatcher.js
+++ b/test/unit/test_dispatcher.js
@@ -29,12 +29,12 @@ describe("Dispatcher", function() {
   it("does not allow cascading dispatches", function(done) {
     store1.__handleAction__ = function() {
       expect(function() {
-        dispatcher.dispatch({type:"action"});
-      }).to.throw(/another action/);
+        dispatcher.dispatch({type:"action2"});
+      }).to.throw(/action2.*another action.*action1/);
       done();
       return true;
     };
-    dispatcher.dispatch({type:"action"});
+    dispatcher.dispatch({type:"action1"});
   });
 
   it("allows back-to-back dispatches on the same tick", function() {


### PR DESCRIPTION
It seems pretty common for people to run into this error, and it might not be obvious which actions are involved when it happens, leading to a lot of logging to try to figure that one.   However, the dispatcher already implicitly knows which actions are involved, so this PR makes that knowledge explicit and relays it through the error that's thrown when there's a dispatch inside another dispatch.
