### PR TITLE
Export Store

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var Dispatcher = require("./lib/dispatcher"),
     FluxMixin = require("./lib/flux_mixin"),
     FluxChildMixin = require("./lib/flux_child_mixin"),
     StoreWatchMixin = require("./lib/store_watch_mixin"),
+    Store = require("./lib/store"),
     createStore = require("./lib/create_store");
 
 var Fluxxor = {
@@ -11,6 +12,7 @@ var Fluxxor = {
   FluxMixin: FluxMixin,
   FluxChildMixin: FluxChildMixin,
   StoreWatchMixin: StoreWatchMixin,
+  Store: Store,
   createStore: createStore,
   version: require("./version")
 };


### PR DESCRIPTION
I changed to export the `lib/store` module. By using this directly, we will be able to create stores by using ES6 Classes style.

For example in TypeScript:

```ts
import Fluxxor = require('fluxxor');

interface MyStoreOption {
  value: number;
}

class MyStore extends Fluxxor.Store {
  options: MyStoreOptions;
  
  constructor(options: MyStoreOption) {
    super();
    this.options = options;
    this.bindActions("ACTION_TYPE", this.handleActionType.bind(this));
  }
  
  handleActionType(payload: number) {
    // ...
  }
};

var myStore = new MyStore({value: 123});
```

In addition, this style is compatible with static typing such as TypeScript.