### PR TITLE
Fix store initialize with nill argument

### DIFF
--- a/lib/create_store.js
+++ b/lib/create_store.js
@@ -13,7 +13,6 @@ var createStore = function(spec) {
   });
 
   var constructor = function(options) {
-    options = options || {};
     Store.call(this);
 
     for (var key in spec) {


### PR DESCRIPTION
At the moment there is no way to initialize a store with a nil value. 

There are some use cases that should allow us to do this. 

e.g.: creating a store with account information and checking if it's nil in order to show some account specific options (like adding a comment on a article)