### PR TITLE
Implement Dehydration/Rehydration

### DIFF
--- a/lib/flux.js
+++ b/lib/flux.js
@@ -28,6 +28,7 @@ var Flux = function(stores, actions) {
   this.actions = {};
   this.stores = {};
 
+  var ctx = this.importFluxxorContextAsScript();
   var dispatcher = this.dispatcher;
   var flux = this;
   this.dispatchBinder = {
@@ -41,6 +42,7 @@ var Flux = function(stores, actions) {
     }
   };
 
+  this.rehydrateStores(stores, ctx);
   this.addActions(actions);
   this.addStores(stores);
 };
@@ -118,6 +120,40 @@ Flux.prototype.addStores = function(stores) {
       this.addStore(key, stores[key]);
     }
   }
+};
+
+Flux.prototype.dehydrateStores = function() {
+  var stores = this.stores;
+  var dehydratedStores = {};
+  for (var key in stores) {
+    if (stores[key].hasOwnProperty('dehydrate')) {
+      dehydratedStores[key] = stores[key].dehydrate();
+    }
+  }
+  return dehydratedStores;
+};
+
+Flux.prototype.rehydrateStores = function(stores, dehydratedStores) {
+  for (var key in stores) {
+    if (stores[key].hasOwnProperty('rehydrate') &&
+        dehydratedStores.hasOwnProperty(key)) {
+      stores[key].rehydrate(dehydratedStores[key]);
+    }
+  }
+
+  return stores;
+};
+
+Flux.prototype.exportFluxxorContextAsScript = function() {
+  return 'window.FluxxorContext=\'' + JSON.stringify(this.dehydrateStores()) + '\'';
+};
+
+Flux.prototype.importFluxxorContextAsScript = function() {
+  if(typeof window === 'object' && window.FluxxorContext) {
+    return JSON.parse(window.FluxxorContext);
+  }
+
+  return {};
 };
 
 Flux.prototype.setDispatchInterceptor = function(fn) {

--- a/lib/flux.js
+++ b/lib/flux.js
@@ -145,7 +145,8 @@ Flux.prototype.rehydrateStores = function(stores, dehydratedStores) {
 };
 
 Flux.prototype.exportFluxxorContextAsScript = function() {
-  return 'window.FluxxorContext=\'' + JSON.stringify(this.dehydrateStores()) + '\'';
+  var ctxString = JSON.stringify(this.dehydrateStores()).replace(/'/g, "\\'" ).replace(/"/g, "\\\"" );
+  return 'window.FluxxorContext=\'' + ctxString + '\'';
 };
 
 Flux.prototype.importFluxxorContextAsScript = function() {

--- a/test/unit/test_flux.js
+++ b/test/unit/test_flux.js
@@ -248,7 +248,7 @@ describe("Flux", function() {
     var ctx = flux.exportFluxxorContextAsScript();
 
     expect(spy).to.have.been.calledWith({ prop: 'test' });
-    expect(ctx).to.equal('window.FluxxorContext=\'{"Store1":{"prop":"test"}}\'');
+    expect(ctx).to.equal('window.FluxxorContext=\'{\\"Store1\\":{\\"prop\\":\\"test\\"}}\'');
   });
 
   it("rehidrate stores", function() {

--- a/test/unit/test_flux.js
+++ b/test/unit/test_flux.js
@@ -229,6 +229,54 @@ describe("Flux", function() {
     }).to.throw(/last argument.*function/);
   });
 
+  it("exports the correct hidratated data", function() {
+    var spy = sinon.spy();
+
+    var Store1 = Fluxxor.createStore({
+      initialize: function() {
+        this.prop = 'test';
+      },
+      dehydrate: function() {
+        var data = { prop: this.prop };
+        spy(data);
+        return data;
+      }
+    });
+
+    var stores = {Store1: new Store1(), Store2: {}};
+    var flux = new Fluxxor.Flux(stores, {});
+    var ctx = flux.exportFluxxorContextAsScript();
+
+    expect(spy).to.have.been.calledWith({ prop: 'test' });
+    expect(ctx).to.equal('window.FluxxorContext=\'{"Store1":{"prop":"test"}}\'');
+  });
+
+  it("rehidrate stores", function() {
+    var spy = sinon.spy();
+
+    var Store1 = Fluxxor.createStore({
+      initialize: function() {
+        this.prop = undefined;
+      },
+      rehydrate: function(store) {
+        spy(store);
+        this.prop = store.prop;
+      }
+    });
+
+    function stubbedImportFluxxorContextAsScript() {
+      return {Store1: {prop: "test"}};
+    }
+
+    sinon.stub(Fluxxor.Flux.prototype, "importFluxxorContextAsScript", stubbedImportFluxxorContextAsScript);
+
+    var stores = { Store1: new Store1() };
+    var flux = new Fluxxor.Flux(stores, {});
+
+    expect(spy).to.have.been.calledWith({ prop: 'test' });
+    expect(flux.stores.Store1.prop).to.equal('test');
+  });
+
   describe("emitting dispatching", function() {
     beforeEach(function() {
       sinon.stub(console, "warn");


### PR DESCRIPTION
Stores can provide `dehydrate` and `rehydrate` methods so that you can
propagate the initial server state to the client.
